### PR TITLE
Add Travis CI Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+language: java


### PR DESCRIPTION
Fixes #18

.travis.yml
  - Declare source language to be Java. Gradle is picked up as the build
  tool automatically.