### PR TITLE
fixed output of jacoco html report

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,5 @@ jacocoTestReport {
     reports {
         xml.enabled = true  // coveralls plugin depends on xml format report
         html.enabled = true
-        html.destination file("${buildDir}/jacocoHtml")
     }
 }


### PR DESCRIPTION
just a small change so that the html report gets generated and placed in 
build/reports/jacoco/test/html/index.html